### PR TITLE
Default Methodes for events 

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,6 @@ void timeout_OnKeyAdded(string key)
    TimeoutContext<Action, object> timeout = new TimeoutContext<Action, object>();
 
 
-
-timeout.OnScheduledItemExpired += Timeout_OnScheduledItemExpired;
-
 timeout.SetTimeout(() =>
 {
     Console.WriteLine("10 seccend task timeouted");
@@ -75,10 +72,7 @@ timeout.SetTimeout(() =>
 }, null, new TimeSpan(hours: 0, 0, 15));
 
 
-void Timeout_OnScheduledItemExpired(Action key)
-{
-    key();
-}
+
 ```
     
     

--- a/TimeoutNet.cs
+++ b/TimeoutNet.cs
@@ -6,9 +6,14 @@ namespace Timeout.Net
     {
         private readonly ConcurrentDictionary<TKey, Tuple<TValue, Task>> _dictionary = new ConcurrentDictionary<TKey, Tuple<TValue, Task>>();
         public delegate void KeyChange(TKey key);
-        
+
         public event KeyChange OnScheduledItemExpired;
         public event KeyChange OnItemScheduled;
+
+        public TimeoutNet()
+        {
+            this.OnScheduledItemExpired += TimeOutStatics.DefaultScheduledExpired;
+        }
 
         public void SetTimeout(TKey key, TValue value, TimeSpan timeSpan)
         {
@@ -40,6 +45,15 @@ namespace Timeout.Net
 
             value = default;
             return false;
+        }
+    }
+
+    public static class TimeOutStatics
+    {
+        // By default, this method is assigned to delegate "OnScheduledItemExpired" when the class is created
+        public static void DefaultScheduledExpired(Action key)
+        {
+            key();
         }
     }
 }


### PR DESCRIPTION
In your example, you created a handler that receives the Action and executes it.  Well, most of the time, nothing more is needed.  So why should we write it ourselves every time to use it in the library when it can exist by default in the project?